### PR TITLE
Use 2.7.13 instead of 2.7_with_system_site_packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     include:
         - python: 2.7.13
           env: {TOX_ENV: py27-cov, COVERAGE: 1}
-        - python: 2.7_with_system_site_packages
+        - python: 2.7.13
           env: {TOX_ENV: py27-test}
         - python: 3.4
           env: {TOX_ENV: py34-test}


### PR DESCRIPTION
`2.7_with_system_site_packages` uses a four-year-old Python 2.7.6.

This allows the latest version of pylast which supports Python 2.7.10+ as older versions don't have good HTTPS support.

Re: https://github.com/pylast/pylast/issues/201.